### PR TITLE
Update Fly.io deployment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /build/
+.envrc.local

--- a/bb.edn
+++ b/bb.edn
@@ -10,7 +10,7 @@
 
          fly:deploy {:depends [docker:build]
                      :doc "Deploy site to fly.io"
-                     :task (do (shell (str "flyctl deploy --image " image-name))
+                     :task (do (shell (str "flyctl deploy --local-only --image " image-name))
                                (println (str "Site deployed. To view it, navigate to https://" image-name ".fly.dev/")))}
 
          site:build {:doc "Build site"

--- a/fly.toml
+++ b/fly.toml
@@ -1,42 +1,45 @@
-# fly.toml file generated for gensql-documentation on 2022-07-06T12:30:52-04:00
+# fly.toml app configuration file generated for gensql-documentation on 2024-05-06T21:41:45+07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
-app = "gensql-documentation"
-kill_signal = "SIGINT"
-kill_timeout = 5
-processes = []
-
-[build]
-  image = "gensql-documentation"
-
-[env]
-  PORT = "8080"
+app = 'gensql-documentation'
+primary_region = 'bos'
+kill_signal = 'SIGINT'
+kill_timeout = '5s'
 
 [experimental]
-  allowed_public_ports = []
   auto_rollback = true
 
+[build]
+  image = 'gensql.documentation'
+
+[env]
+  PORT = '8080'
+
 [[services]]
-  http_checks = []
+  protocol = 'tcp'
   internal_port = 8080
-  processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
+  processes = ['app']
+
+  [[services.ports]]
+    port = 80
+    handlers = ['http']
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ['tls', 'http']
+
   [services.concurrency]
+    type = 'connections'
     hard_limit = 25
     soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
 
   [[services.tcp_checks]]
-    grace_period = "1s"
-    interval = "15s"
-    restart_limit = 0
-    timeout = "2s"
+    interval = '15s'
+    timeout = '2s'
+    grace_period = '1s'
+
+[[vm]]
+  size = 'shared-cpu-1x'


### PR DESCRIPTION
This updates the fly.io config to deploy the documentation website, https://gensql-documentation.fly.dev/.

The changes to fly.toml are boilerplate created by `flyctl`.

The babashka task to deploy required the addition of the `--local-only` flag, since otherwise, flyctl looks for a remote image, but afaict, we don't push the built image anywhere, it only exists in our local machines. My guess is fly used to look both locally and remotely, but doesn't now.

In addition, I duplicated the inferenceql-documentation` Fly app to `gensql-documentation` (see https://fly.io/dashboard/inferenceql-543). However, something changed, either in Fly's deployment or our images, and the old 256 MB RAM limit kept resulting in OOM errors, so I bumped it up to 512 MB for the new app.

One other difference is Fly now hands out shared IPv4 addresses by default, instead of unique IPv4. It seems to be working just fine, though, so I left that alone.

The .envrc, .envrc.local, and the .gitignore change are so I can set private credentials with direnv, but not commit them.

